### PR TITLE
[74] Expand permission enum to cover the rest of the permissions listed

### DIFF
--- a/src/main/java/org/irods/Util/Permission.java
+++ b/src/main/java/org/irods/Util/Permission.java
@@ -4,11 +4,19 @@ package org.irods.Util;
  * enum for set_permission() method to ensure user only inputs valid data
  */
 public enum Permission {
-    NULL("null"),
-    READ("read"),
+    OWN("own"),
+    DELETE_OBJECT("delete_object"),
     WRITE("write"),
-    OWN("own");
-    
+    MODIFY_OBJECT("modify_object"),
+    CREATE_OBJECT("create_object"),
+    DELETE_METADATA("delete_metadata"),
+    MODIFY_METADATA("modify_metadata"),
+    CREATE_METADATA("create_metadata"),
+    READ("read"),
+    READ_OBJECT("read_object"),
+    READ_METADATA("read_metadata"),
+    NULL("null");
+
     private final String value; 
     
     Permission(String value) {


### PR DESCRIPTION
Addresses #74. All tests pass. 

Not sure if I should include `modify_object` and `read_object` since it's equivalent to `write` and `own`. 